### PR TITLE
Dry run

### DIFF
--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -91,5 +91,8 @@ namespace FM.LiveSwitch.Mux
 
         [Option("save-filter-files", Required = false, HelpText = "Do not delete the filter files. Ignored if --no-filter-files is set.")]
         public bool SaveFilterFiles { get; set; }
+
+        [Option("dry-run", Required = false, HelpText = "Do a dry-run with no muxing.")]
+        public bool DryRun { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -152,7 +152,7 @@ namespace FM.LiveSwitch.Mux
                                 }
                             }
 
-                            if (WriteMetadata(session))
+                            if (session.WriteMetadata(Options))
                             {
                                 metadataFiles.Add(session.MetadataFile);
                             }
@@ -281,21 +281,6 @@ namespace FM.LiveSwitch.Mux
                 Console.Error.WriteLine($"Could not delete {file}. {ex}");
             }
             return false;
-        }
-
-        private bool WriteMetadata(Session session)
-        {
-            session.MetadataFile = Path.Combine(Path.GetDirectoryName(session.File), $"{Path.GetFileNameWithoutExtension(session.File)}.json");
-
-            var outputPath = Path.GetDirectoryName(session.MetadataFile);
-            if (!Directory.Exists(outputPath))
-            {
-                Directory.CreateDirectory(outputPath);
-            }
-
-            File.WriteAllText(session.MetadataFile, JsonConvert.SerializeObject(session));
-
-            return session.MetadataFileExists;
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -217,6 +217,11 @@ namespace FM.LiveSwitch.Mux
             }
             arguments.Add(File);
 
+            if (options.DryRun)
+            {
+                return true;
+            }
+
             var outputPath = Path.GetDirectoryName(File);
             if (!Directory.Exists(outputPath))
             {
@@ -309,6 +314,11 @@ namespace FM.LiveSwitch.Mux
                     arguments.Add($"-codec:a {options.AudioCodec}");
                 }
                 arguments.Add(AudioFile);
+
+                if (options.DryRun)
+                {
+                    return true;
+                }
 
                 var outputPath = Path.GetDirectoryName(AudioFile);
                 if (!Directory.Exists(outputPath))
@@ -578,6 +588,11 @@ namespace FM.LiveSwitch.Mux
                 }
                 arguments.Add(VideoFile);
 
+                if (options.DryRun)
+                {
+                    return true;
+                }
+
                 var outputPath = Path.GetDirectoryName(VideoFile);
                 if (!Directory.Exists(outputPath))
                 {
@@ -791,6 +806,40 @@ namespace FM.LiveSwitch.Mux
             catch (Win32Exception wex)
             {
                 throw new Exception($"Could not start {command}. Is ffmpeg installed and available on your PATH?", wex);
+            }
+        }
+
+        public bool WriteMetadata(MuxOptions options)
+        {
+            MetadataFile = Path.Combine(Path.GetDirectoryName(File), $"{Path.GetFileNameWithoutExtension(File)}.json");
+
+            var outputPath = Path.GetDirectoryName(MetadataFile);
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+
+            var file = File;
+            var audioFile = AudioFile;
+            var videoFile = VideoFile;
+            try
+            {
+                if (options.DryRun)
+                {
+                    File = null;
+                    AudioFile = null;
+                    VideoFile = null;
+                }
+
+                System.IO.File.WriteAllText(MetadataFile, JsonConvert.SerializeObject(this));
+
+                return MetadataFileExists;
+            }
+            finally
+            {
+                File = file;
+                AudioFile = audioFile;
+                VideoFile = videoFile;
             }
         }
     }


### PR DESCRIPTION
- Added a `dry-run` option to bypass muxing if all we want is the JSON output for completed session details.