### PR TITLE
Session IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,19 @@ lsmux [options]
   --js-file              For JS layout, the JavaScript file path. Defaults to layout.js in the
                          input path.
 
-  --trim-first           (Default: false) Trim audio from the first participant before any other
-                         participants have joined. Requires the --no-video flag.
+  --trim-first           Trim audio from the first participant before any other participants
+                         have joined. Requires the --no-video flag.
 
-  --trim-last            (Default: false) Trim audio from the last participant after all other
-                         participants have left. Requires the --no-video flag.
+  --trim-last            Trim audio from the last participant after all other participants have
+                         left. Requires the --no-video flag.
 
   --no-filter-files      Do not use files for the filters. Pass the filters as arguments.
 
   --save-filter-files    Do not delete the filter files. Ignored if --no-filter-files is set.
 
   --dry-run              Do a dry-run with no muxing.
+
+  --session-id           The session ID to mux, obtained from a dry-run.
 ```
 
 The `input-path` to your recordings defaults to the current directory, but can be set to target another directory on disk.

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -8,91 +8,94 @@ namespace FM.LiveSwitch.Mux
         public const int MinWidth = 160;
         public const int MinHeight = 120;
 
-        [Option('i', "input-path", Required = false, Default = null, HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
+        [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
 
-        [Option('o', "output-path", Required = false, Default = null, HelpText = "The output path for muxed sessions. Defaults to the input path.")]
+        [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]
         public string OutputPath { get; set; }
 
-        [Option('s', "strategy", Required = false, Default = StrategyType.AutoDetect, HelpText = "The recording strategy used by the media server.")]
+        [Option('s', "strategy", Default = StrategyType.AutoDetect, HelpText = "The recording strategy used by the media server.")]
         public StrategyType Strategy { get; set; }
 
-        [Option('l', "layout", Required = false, Default = LayoutType.HGrid, HelpText = "The video layout to use.")]
+        [Option('l', "layout", Default = LayoutType.HGrid, HelpText = "The video layout to use.")]
         public LayoutType Layout { get; set; }
 
-        [Option('m', "margin", Required = false, Default = 0, HelpText = "The margin, in pixels, to insert between videos in the layout.")]
+        [Option('m', "margin", Default = 0, HelpText = "The margin, in pixels, to insert between videos in the layout.")]
         public int Margin { get; set; }
 
-        [Option('w', "width", Required = false, Default = 1920, HelpText = "The pixel width of the output video.")]
+        [Option('w', "width", Default = 1920, HelpText = "The pixel width of the output video.")]
         public int Width { get; set; }
 
-        [Option('h', "height", Required = false, Default = 1080, HelpText = "The pixel height of the output video.")]
+        [Option('h', "height", Default = 1080, HelpText = "The pixel height of the output video.")]
         public int Height { get; set; }
 
-        [Option('f', "frame-rate", Required = false, Default = 30, HelpText = "The frames per second of the output video.")]
+        [Option('f', "frame-rate", Default = 30, HelpText = "The frames per second of the output video.")]
         public int FrameRate { get; set; }
 
-        [Option("background-color", Required = false, Default = "000000", HelpText = "The background colour.")]
+        [Option("background-color", Default = "000000", HelpText = "The background colour.")]
         public string BackgroundColor { get; set; }
 
-        [Option("audio-codec", Required = false, Default = "libopus", HelpText = "The output audio codec and options.")]
+        [Option("audio-codec", Default = "libopus", HelpText = "The output audio codec and options.")]
         public string AudioCodec { get; set; }
 
-        [Option("video-codec", Required = false, Default = "libvpx -auto-alt-ref 0", HelpText = "The output video codec and options.")]
+        [Option("video-codec", Default = "libvpx -auto-alt-ref 0", HelpText = "The output video codec and options.")]
         public string VideoCodec { get; set; }
 
-        [Option("audio-container", Required = false, Default = "mka", HelpText = "The output audio container (file extension).")]
+        [Option("audio-container", Default = "mka", HelpText = "The output audio container (file extension).")]
         public string AudioContainer{ get; set; }
 
-        [Option("video-container", Required = false, Default = "mkv", HelpText = "The output video container (file extension).")]
+        [Option("video-container", Default = "mkv", HelpText = "The output video container (file extension).")]
         public string VideoContainer { get; set; }
 
-        [Option("dynamic", Required = false, HelpText = "Dynamically update the video layout as recordings start and stop.")]
+        [Option("dynamic", HelpText = "Dynamically update the video layout as recordings start and stop.")]
         public bool Dynamic { get; set; }
 
-        [Option("crop", Required = false, HelpText = "Crop video in order to use all available layout space.")]
+        [Option("crop", HelpText = "Crop video in order to use all available layout space.")]
         public bool Crop { get; set; }
 
-        [Option("no-audio", Required = false, HelpText = "Do not mux audio.")]
+        [Option("no-audio", HelpText = "Do not mux audio.")]
         public bool NoAudio { get; set; }
 
-        [Option("no-video", Required = false, HelpText = "Do not mux video.")]
+        [Option("no-video", HelpText = "Do not mux video.")]
         public bool NoVideo { get; set; }
 
-        [Option("move-inputs", Required = false, HelpText = "Move input files to the output path.")]
+        [Option("move-inputs", HelpText = "Move input files to the output path.")]
         public bool MoveInputs { get; set; }
 
-        [Option("delete-inputs", Required = false, HelpText = "Delete input files from the input path.")]
+        [Option("delete-inputs", HelpText = "Delete input files from the input path.")]
         public bool DeleteInputs { get; set; }
 
-        [Option("no-prompt", Required = false, HelpText = "Do not prompt before deleting.")]
+        [Option("no-prompt", HelpText = "Do not prompt before deleting.")]
         public bool NoPrompt { get; set; }
 
-        [Option("application-id", Required = false, Default = null, HelpText = "The application ID to mux.")]
+        [Option("application-id", HelpText = "The application ID to mux.")]
         public string ApplicationId { get; set; }
 
-        [Option("channel-id", Required = false, Default = null, HelpText = "The channel ID to mux.")]
+        [Option("channel-id", HelpText = "The channel ID to mux.")]
         public string ChannelId { get; set; }
 
-        [Option("output-file-name", Required = false, Default = "session_{startTimestamp}_to_{stopTimestamp}", HelpText = "The output file name template. Uses curly-brace syntax (e.g. {channelId}). Valid variables: applicationId, channelId, startTimestamp, stopTimestamp")]
+        [Option("output-file-name", Default = "session_{startTimestamp}_to_{stopTimestamp}", HelpText = "The output file name template. Uses curly-brace syntax (e.g. {channelId}). Valid variables: applicationId, channelId, startTimestamp, stopTimestamp")]
         public string OutputFileName { get; set; }
 
-        [Option("js-file", Required = false, Default = null, HelpText = "For JS layout, the JavaScript file path. Defaults to layout.js in the input path.")]
+        [Option("js-file", HelpText = "For JS layout, the JavaScript file path. Defaults to layout.js in the input path.")]
         public string JavaScriptFile { get; set; }
 
-        [Option("trim-first", Default = false, Required = false, HelpText = "Trim audio from the first participant before any other participants have joined. Requires the --no-video flag.")]
+        [Option("trim-first", HelpText = "Trim audio from the first participant before any other participants have joined. Requires the --no-video flag.")]
         public bool TrimFirst { get; set; }
 
-        [Option("trim-last", Default = false, Required = false, HelpText = "Trim audio from the last participant after all other participants have left. Requires the --no-video flag.")]
+        [Option("trim-last", HelpText = "Trim audio from the last participant after all other participants have left. Requires the --no-video flag.")]
         public bool TrimLast { get; set; }
 
-        [Option("no-filter-files", Required = false, HelpText = "Do not use files for the filters. Pass the filters as arguments.")]
+        [Option("no-filter-files", HelpText = "Do not use files for the filters. Pass the filters as arguments.")]
         public bool NoFilterFiles { get; set; }
 
-        [Option("save-filter-files", Required = false, HelpText = "Do not delete the filter files. Ignored if --no-filter-files is set.")]
+        [Option("save-filter-files", HelpText = "Do not delete the filter files. Ignored if --no-filter-files is set.")]
         public bool SaveFilterFiles { get; set; }
 
-        [Option("dry-run", Required = false, HelpText = "Do a dry-run with no muxing.")]
+        [Option("dry-run", HelpText = "Do a dry-run with no muxing.")]
         public bool DryRun { get; set; }
+
+        [Option("session-id", HelpText = "The session ID to mux, obtained from a dry-run.")]
+        public string SessionId { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -104,6 +104,11 @@ namespace FM.LiveSwitch.Mux
                     }
                     foreach (var session in channel.CompletedSessions)
                     {
+                        if (Options.SessionId != null && Options.SessionId != session.Id)
+                        {
+                            continue;
+                        }
+
                         Console.Error.WriteLine();
                         Console.Error.WriteLine($"Channel {channel.Id} from application {application.Id} is ready for muxing ({session.StartTimestamp} to {session.StopTimestamp}).");
 

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -19,7 +19,7 @@ namespace FM.LiveSwitch.Mux
             get
             {
                 // sha(connectionId:connectionId:..)
-                var input = $"{string.Join(":", CompletedConnections.Select(x => x.Id))}";
+                var input = $"{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
                 using (var sha = new SHA1Managed())
                 {
                     return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(input))).Replace("-", "").ToLower();
@@ -35,6 +35,8 @@ namespace FM.LiveSwitch.Mux
 
         [JsonIgnore]
         public string VideoFileName { get; set; }
+
+        public string Id { get { return Hash; } }
 
         public string ChannelId { get; private set; }
 


### PR DESCRIPTION
- Added `id` to session JSON output. The session ID is calculated as a SHA-1 hash of the concatenation of the connection IDs (each of which is a UUID) separated by colons, e.g. `sha(connectionId:connectionId:..)`.
- Added `session-id` command-line argument to mux a specific session. The expectation is that session IDs can be calculated using the `dry-run` option, and then specific sessions can be muxed afterwards.