### PR TITLE
Filling in missing audio

### DIFF
--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -69,6 +69,11 @@ namespace FM.LiveSwitch.Mux
         {
             get
             {
+                if (VideoSegments == null)
+                {
+                    return null;
+                }
+
                 var lastSegment = (VideoSegment)null;
                 var videoEvents = new List<VideoEvent>();
                 foreach (var segment in VideoSegments)
@@ -102,6 +107,12 @@ namespace FM.LiveSwitch.Mux
                 });
                 return videoEvents.ToArray();
             }
+        }
+
+        public string GetAudioResampleFilterChain(string inputTag, string outputTag)
+        {
+            // sync to timestamps using stretching, squeezing, filling and trimming
+            return $"{inputTag}aresample=async=1{outputTag}";
         }
 
         public string GetAudioDelayFilterChain(DateTime sessionStartTimestamp, string inputTag, string outputTag)

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -389,8 +389,12 @@ namespace FM.LiveSwitch.Mux
             {
                 // initialize tag
                 var recordingTag = recording.AudioTag;
+                var resampleTag = $"[aresample_{recording.AudioIndex}]";
                 var delayTag = $"[adelay_{recording.AudioIndex}]";
                 var trimTag = $"[atrim_{recording.AudioIndex}]";
+
+                // resample
+                filterChains.Add(recording.GetAudioResampleFilterChain(recordingTag, recordingTag = delayTag));
 
                 // delay
                 filterChains.Add(recording.GetAudioDelayFilterChain(StartTimestamp, recordingTag, recordingTag = delayTag));


### PR DESCRIPTION
- Added the `aresample` filter to the audio processing pipeline so missing audio packets (timestamp gaps) in the input audio recording are honoured.
- Added a null-check in the `Recording.VideoEvents` getter to avoid null reference exceptions when debugging and inspecting `Recording` instance properties.