### PR TITLE
MD5 and IDs

### DIFF
--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -75,7 +75,7 @@ namespace FM.LiveSwitch.Mux
         [Option("channel-id", HelpText = "The channel ID to mux.")]
         public string ChannelId { get; set; }
 
-        [Option("output-file-name", Default = "session_{startTimestamp}_to_{stopTimestamp}", HelpText = "The output file name template. Uses curly-brace syntax (e.g. {channelId}). Valid variables: applicationId, channelId, startTimestamp, stopTimestamp")]
+        [Option("output-file-name", Default = "session_{startTimestamp}_to_{stopTimestamp}_{sessionId}", HelpText = "The output file name template. Uses curly-brace syntax (e.g. {channelId}). Valid variables: applicationId, channelId, sessionId, startTimestamp, stopTimestamp")]
         public string OutputFileName { get; set; }
 
         [Option("js-file", HelpText = "For JS layout, the JavaScript file path. Defaults to layout.js in the input path.")]

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using System;
 
 namespace FM.LiveSwitch.Mux
 {
@@ -96,6 +97,6 @@ namespace FM.LiveSwitch.Mux
         public bool DryRun { get; set; }
 
         [Option("session-id", HelpText = "The session ID to mux, obtained from a dry-run.")]
-        public string SessionId { get; set; }
+        public Guid? SessionId { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -12,8 +12,27 @@ namespace FM.LiveSwitch.Mux
         {
             get
             {
-                // md5(startTimestampTicks:connectionId)
-                var input = $"{StartTimestamp.Ticks}:{Connection.Id}";
+                var input = $"{AudioId}:{VideoId}";
+                using var md5 = MD5.Create();
+                return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
+            }
+        }
+
+        public Guid? AudioId
+        {
+            get
+            {
+                var input = $"{AudioStartTimestamp?.Ticks}:{Connection.Id}:audio";
+                using var md5 = MD5.Create();
+                return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
+            }
+        }
+
+        public Guid? VideoId
+        {
+            get
+            {
+                var input = $"{VideoStartTimestamp?.Ticks}:{Connection.Id}:video";
                 using var md5 = MD5.Create();
                 return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
             }

--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -1,11 +1,24 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace FM.LiveSwitch.Mux
 {
     public class Recording
     {
+        public Guid Id
+        {
+            get
+            {
+                // md5(startTimestampTicks:connectionId)
+                var input = $"{StartTimestamp.Ticks}:{Connection.Id}";
+                using var md5 = MD5.Create();
+                return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
+            }
+        }
+
         public DateTime StartTimestamp { get; set; }
 
         public DateTime StopTimestamp { get; set; }

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -14,20 +14,6 @@ namespace FM.LiveSwitch.Mux
     public class Session
     {
         [JsonIgnore]
-        public string Hash
-        {
-            get
-            {
-                // sha(connectionId:connectionId:..)
-                var input = $"{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
-                using (var sha = new SHA1Managed())
-                {
-                    return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(input))).Replace("-", "").ToLower();
-                }
-            }
-        }
-
-        [JsonIgnore]
         public string FileName { get; set; }
 
         [JsonIgnore]
@@ -36,7 +22,16 @@ namespace FM.LiveSwitch.Mux
         [JsonIgnore]
         public string VideoFileName { get; set; }
 
-        public string Id { get { return Hash; } }
+        public Guid Id
+        { 
+            get
+            {
+                // sha(connectionId:connectionId:..)
+                var input = $"{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
+                using var md5 = MD5.Create();
+                return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
+            } 
+        }
 
         public string ChannelId { get; private set; }
 

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -237,6 +237,7 @@ namespace FM.LiveSwitch.Mux
             return outputFileName
                 .Replace("{applicationId}", ApplicationId)
                 .Replace("{channelId}", ChannelId)
+                .Replace("{sessionId}", Id.ToString())
                 .Replace("{startTimestamp}", StartTimestamp.ToString(Iso8601FileSafeFormat))
                 .Replace("{stopTimestamp}", StopTimestamp.ToString(Iso8601FileSafeFormat));
         }

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -26,8 +26,7 @@ namespace FM.LiveSwitch.Mux
         { 
             get
             {
-                // md5(startTimestampTicks:connectionId:connectionId:..)
-                var input = $"{StartTimestamp.Ticks}:{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
+                var input = string.Join(":", CompletedRecordings.Select(x => x.Id).OrderBy(x => x));
                 using var md5 = MD5.Create();
                 return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
             } 

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -26,8 +26,8 @@ namespace FM.LiveSwitch.Mux
         { 
             get
             {
-                // sha(connectionId:connectionId:..)
-                var input = $"{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
+                // md5(startTimestampTicks:connectionId:connectionId:..)
+                var input = $"{StartTimestamp.Ticks}:{string.Join(":", CompletedConnections.Select(x => x.Id).OrderBy(x => x))}";
                 using var md5 = MD5.Create();
                 return new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
             } 


### PR DESCRIPTION
- Switched to MD5/UUID for session IDs to match LiveSwitch Cloud recording session IDs.
- Added `audioId`, `videoId`, and `id` to JSON output for recording entities.
- Added `id` to JSON output for session entities.
- Added `{sessionId}` to list of supported variables for `--output-file-name`.
- Updated default value for `--output-file-name` to `session_{startTimestamp}_to_{stopTimestamp}_{sessionId}` (added `_{sessionId}` suffix) to avoid conflicts between sessions that start and stop at the exact same time.