### PR TITLE
Allow relative paths in the recording JSON

### DIFF
--- a/src/FM.LiveSwitch.Mux/Application.cs
+++ b/src/FM.LiveSwitch.Mux/Application.cs
@@ -21,7 +21,7 @@ namespace FM.LiveSwitch.Mux
             Id = id;
         }
 
-        public bool ProcessLogEntry(LogEntry logEntry)
+        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var channelId = logEntry.ChannelId;
             if (channelId == null)
@@ -34,7 +34,7 @@ namespace FM.LiveSwitch.Mux
                 _Channels[channelId] = channel = new Channel(channelId, Id);
             }
 
-            return channel.ProcessLogEntry(logEntry);
+            return channel.ProcessLogEntry(logEntry, options);
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Channel.cs
+++ b/src/FM.LiveSwitch.Mux/Channel.cs
@@ -60,7 +60,7 @@ namespace FM.LiveSwitch.Mux
             ApplicationId = applicationId;
         }
 
-        public bool ProcessLogEntry(LogEntry logEntry)
+        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var clientId = logEntry.ClientId;
             if (clientId == null)
@@ -73,7 +73,7 @@ namespace FM.LiveSwitch.Mux
                 _Clients[clientId] = client = new Client(clientId, logEntry.DeviceId, logEntry.UserId, Id, ApplicationId);
             }
 
-            var result = client.ProcessLogEntry(logEntry);
+            var result = client.ProcessLogEntry(logEntry, options);
 
             if (Completed)
             {

--- a/src/FM.LiveSwitch.Mux/Client.cs
+++ b/src/FM.LiveSwitch.Mux/Client.cs
@@ -77,7 +77,7 @@ namespace FM.LiveSwitch.Mux
             ApplicationId = applicationId;
         }
 
-        public bool ProcessLogEntry(LogEntry logEntry)
+        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var connectionId = logEntry.ConnectionId;
             if (connectionId == null)
@@ -93,7 +93,7 @@ namespace FM.LiveSwitch.Mux
                 };
             }
 
-            return connection.ProcessLogEntry(logEntry);
+            return connection.ProcessLogEntry(logEntry, options);
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Connection.cs
+++ b/src/FM.LiveSwitch.Mux/Connection.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace FM.LiveSwitch.Mux
@@ -58,7 +59,7 @@ namespace FM.LiveSwitch.Mux
             ApplicationId = applicationId;
         }
 
-        public bool ProcessLogEntry(LogEntry logEntry)
+        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             if (logEntry.Type == LogEntry.TypeStartRecording)
             {
@@ -111,12 +112,22 @@ namespace FM.LiveSwitch.Mux
                 {
                     ActiveRecording.AudioStartTimestamp = logEntry.Data?.AudioFirstFrameTimestamp ?? ActiveRecording.StartTimestamp;
                     ActiveRecording.AudioStopTimestamp = logEntry.Data?.AudioLastFrameTimestamp ?? ActiveRecording.StopTimestamp;
+
+                    if (!Path.IsPathRooted(ActiveRecording.AudioFile))
+                    {
+                        ActiveRecording.AudioFile = Path.Combine(options.InputPath, ActiveRecording.AudioFile);
+                    }
                 }
 
                 if (ActiveRecording.VideoFile != null)
                 {
                     ActiveRecording.VideoStartTimestamp = logEntry.Data?.VideoFirstFrameTimestamp ?? ActiveRecording.StartTimestamp;
                     ActiveRecording.VideoStopTimestamp = logEntry.Data?.VideoLastFrameTimestamp ?? ActiveRecording.StopTimestamp;
+
+                    if (!Path.IsPathRooted(ActiveRecording.VideoFile))
+                    {
+                        ActiveRecording.VideoFile = Path.Combine(options.InputPath, ActiveRecording.VideoFile);
+                    }
                 }
 
                 _Recordings.Add(ActiveRecording);

--- a/src/FM.LiveSwitch.Mux/Context.cs
+++ b/src/FM.LiveSwitch.Mux/Context.cs
@@ -13,7 +13,7 @@ namespace FM.LiveSwitch.Mux
 
         private Dictionary<string, Application> _Applications = new Dictionary<string, Application>();
 
-        public bool ProcessLogEntry(LogEntry logEntry)
+        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var applicationId = logEntry.ApplicationId;
             if (applicationId == null)
@@ -26,7 +26,7 @@ namespace FM.LiveSwitch.Mux
                 _Applications[applicationId] = application = new Application(applicationId);
             }
 
-            return application.ProcessLogEntry(logEntry);
+            return application.ProcessLogEntry(logEntry, options);
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -85,7 +85,7 @@ namespace FM.LiveSwitch.Mux
             var context = new Context();
             foreach (var logEntry in logEntries)
             {
-                context.ProcessLogEntry(logEntry);
+                context.ProcessLogEntry(logEntry, Options);
             }
 
             // process the results

--- a/src/FM.LiveSwitch.Mux/Session.cs
+++ b/src/FM.LiveSwitch.Mux/Session.cs
@@ -197,6 +197,12 @@ namespace FM.LiveSwitch.Mux
                 inputArguments.Add($"-i {VideoFile}");
             }
 
+            if (inputArguments.Count == 0)
+            {
+                Console.Error.WriteLine("No media files found.");
+                return false;
+            }
+
             // pull together the final arguments list
             var arguments = new List<string>
             {


### PR DESCRIPTION
- Audio/video file paths in the recording JSON metadata can be relative now instead of absolute and `lsmux` will assume the root is the input directory. This should make it easier in some cases to migrate mka/mkv/json groups to other servers.