### PR TITLE
Decoding with libopus

### DIFF
--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -60,6 +60,10 @@ namespace FM.LiveSwitch.Mux
 
         public string LogFile { get; set; }
 
+        public string AudioCodec { get; set; }
+
+        public string VideoCodec { get; set; }
+
         [JsonIgnore]
         public bool AudioFileExists
         {


### PR DESCRIPTION
- Added `audioCodec` and `videoCodec` to session JSON for individual recordings.
- Updated audio muxing to prefer `libopus` as the decoder over `opus` when decoding an Opus-encoded input file. The `opus` decoder in the current `ffmpeg` release does not support SILK, which results in audio loss.