### PR TITLE
Case insensitive replace on file move

### DIFF
--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -251,7 +251,7 @@ namespace FM.LiveSwitch.Mux
 
         private string Move(string file, MuxOptions options)
         {
-            var newFile = file.Replace(options.InputPath, options.OutputPath);
+            var newFile = file.Replace(options.InputPath, options.OutputPath, StringComparison.InvariantCultureIgnoreCase);
 
             var outputPath = Path.GetDirectoryName(newFile);
             if (!Directory.Exists(outputPath))


### PR DESCRIPTION
- Updated string replace for file move operation to be case insensitive so a difference in casing on the `--input-path` parameter doesn't impact the ability to move the file following the muxing.