### PR TITLE
FileNotFound exception handling

### DIFF
--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -243,7 +243,14 @@ namespace FM.LiveSwitch.Mux
                         {
                             if (filePath.EndsWith(".json") || filePath.EndsWith(".json.rec"))
                             {
-                                logEntries.AddRange(await LogUtility.GetEntries(filePath));
+                                try
+                                {
+                                    logEntries.AddRange(await LogUtility.GetEntries(filePath));
+                                }
+                                catch (FileNotFoundException)
+                                {
+                                    Console.Error.WriteLine($"Could not read from {filePath} as it no longer exists. Is another process running that could have removed it?");
+                                }
                             }
                         }
                         return logEntries.ToArray();


### PR DESCRIPTION
- Added better handling for cases where multiple instances of `lsmux` are running but targeting different scopes (e.g. different application IDs or different channel IDs). In these cases, there is a chance that while gathering log data, another `lsmux` may have completed a task that resulted in the move or deletion of a *.json or *.json.rec file that was previously enumerated in the directory listing for the current process. This results in a `FileNotFoundException` that is now caught and logged instead of terminating the process due to an unexpected exception.