### PR TITLE
Fixing double formatting

### DIFF
--- a/src/FM.LiveSwitch.Mux/DoubleExtensions.cs
+++ b/src/FM.LiveSwitch.Mux/DoubleExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Mux
+{
+    static class DoubleExtensions
+    {
+        public static double Round(this double value, int places)
+        {
+            var factor = (long)Math.Pow(10, places);
+            return Math.Round(value * factor) / factor;
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -295,7 +295,7 @@ namespace FM.LiveSwitch.Mux
         /// <returns></returns>
         public string GetAudioStartTrimFilterChain(string inputTag, string outputTag, double trim)
         {
-            return $"{inputTag}atrim=start={trim},asetpts=PTS-STARTPTS{outputTag}";
+            return $"{inputTag}atrim=start={trim:.###},asetpts=PTS-STARTPTS{outputTag}";
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace FM.LiveSwitch.Mux
         /// <returns></returns>
         public string GetAudioEndTrimFilterChain(string inputTag, string outputTag, double trim)
         {
-            return $"{inputTag}atrim=end={trim}{outputTag}";
+            return $"{inputTag}atrim=end={trim:.###}{outputTag}";
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -295,7 +295,7 @@ namespace FM.LiveSwitch.Mux
         /// <returns></returns>
         public string GetAudioStartTrimFilterChain(string inputTag, string outputTag, double trim)
         {
-            return $"{inputTag}atrim=start={trim:.###},asetpts=PTS-STARTPTS{outputTag}";
+            return $"{inputTag}atrim=start={trim.Round(3)},asetpts=PTS-STARTPTS{outputTag}";
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace FM.LiveSwitch.Mux
         /// <returns></returns>
         public string GetAudioEndTrimFilterChain(string inputTag, string outputTag, double trim)
         {
-            return $"{inputTag}atrim=end={trim:.###}{outputTag}";
+            return $"{inputTag}atrim=end={trim.Round(3)}{outputTag}";
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux/VideoChunk.cs
+++ b/src/FM.LiveSwitch.Mux/VideoChunk.cs
@@ -30,12 +30,12 @@ namespace FM.LiveSwitch.Mux
 
         public string GetColorFilterChain(string color, string outputTag)
         {
-            return $"color={color}:size={Layout.Size.Width}x{Layout.Size.Height}:duration={Duration.TotalSeconds:.###}{outputTag}";
+            return $"color={color}:size={Layout.Size.Width}x{Layout.Size.Height}:duration={Duration.TotalSeconds.Round(3)}{outputTag}";
         }
 
         public string GetTrimFilterChain(Recording recording, string inputTag, string outputTag)
         {
-            return $"{inputTag}trim=start={(StartTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds:.###}:end={(StopTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds:.###},setpts=PTS-STARTPTS{outputTag}";
+            return $"{inputTag}trim=start={(StartTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds.Round(3)}:end={(StopTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds.Round(3)},setpts=PTS-STARTPTS{outputTag}";
         }
 
         public string GetFpsFilterChain(int frameRate, string inputTag, string outputTag)

--- a/src/FM.LiveSwitch.Mux/VideoChunk.cs
+++ b/src/FM.LiveSwitch.Mux/VideoChunk.cs
@@ -30,12 +30,12 @@ namespace FM.LiveSwitch.Mux
 
         public string GetColorFilterChain(string color, string outputTag)
         {
-            return $"color={color}:size={Layout.Size.Width}x{Layout.Size.Height}:duration={Duration.TotalSeconds}{outputTag}";
+            return $"color={color}:size={Layout.Size.Width}x{Layout.Size.Height}:duration={Duration.TotalSeconds:.###}{outputTag}";
         }
 
         public string GetTrimFilterChain(Recording recording, string inputTag, string outputTag)
         {
-            return $"{inputTag}trim=start={(StartTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds}:end={(StopTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds},setpts=PTS-STARTPTS{outputTag}";
+            return $"{inputTag}trim=start={(StartTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds:.###}:end={(StopTimestamp - recording.VideoStartTimestamp.Value).TotalSeconds:.###},setpts=PTS-STARTPTS{outputTag}";
         }
 
         public string GetFpsFilterChain(int frameRate, string inputTag, string outputTag)


### PR DESCRIPTION
- Fixing double formatting for seconds so that it uses 3 decimal places (milliseconds) instead of unlimited, which can end up using scientific notation.