### PR TITLE
Linux stale file handle

### DIFF
--- a/src/FM.LiveSwitch.Mux/FileUtility.cs
+++ b/src/FM.LiveSwitch.Mux/FileUtility.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Mux

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -253,7 +253,7 @@ namespace FM.LiveSwitch.Mux
                                 }
                                 catch (IOException ex) when (ex.Message.Contains("Stale file handle")) // for Linux
                                 {
-                                    Console.Error.WriteLine($"Could not read from {filePath} as it no longer exists. Is another process running that could have removed it?");
+                                    Console.Error.WriteLine($"Could not read from {filePath} as the file handle is stale. Is another process running that could have removed it?");
                                 }
                             }
                         }

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -251,6 +251,10 @@ namespace FM.LiveSwitch.Mux
                                 {
                                     Console.Error.WriteLine($"Could not read from {filePath} as it no longer exists. Is another process running that could have removed it?");
                                 }
+                                catch (IOException ex) when (ex.Message.Contains("Stale file handle")) // for Linux
+                                {
+                                    Console.Error.WriteLine($"Could not read from {filePath} as it no longer exists. Is another process running that could have removed it?");
+                                }
                             }
                         }
                         return logEntries.ToArray();


### PR DESCRIPTION
- Catches and handles the case where a file is deleted between being opened and being read (stale file handle). This only impacts Linux, as Windows is able to acquire an exclusive lock. There is no code to associate with the error, so instead we are doing a string comparison on the exception message.