### PR TITLE
Fix for lip synchronization

### DIFF
--- a/src/FM.LiveSwitch.Mux.Test/ContextTests.cs
+++ b/src/FM.LiveSwitch.Mux.Test/ContextTests.cs
@@ -66,22 +66,11 @@ namespace FM.LiveSwitch.Mux.Test
             var audioStop = stop;
             var videoStop = stop;
 
-            if (videoDelay > 0)
-            {
-                // positive video delay indicates that video arrived late
-                // and needs to be shuffled back in time to match audio
-                start = start.AddSeconds(-videoDelay);
-                videoStart = videoStart.AddSeconds(-videoDelay);
-                videoStop = videoStop.AddSeconds(-videoDelay);
-            }
-            if (videoDelay < 0)
-            {
-                // negative video delay indicates that audio arrived late
-                // and needs to be shuffled back in time to match video
-                start = start.AddSeconds(videoDelay);
-                audioStart = audioStart.AddSeconds(videoDelay);
-                audioStop = audioStop.AddSeconds(videoDelay);
-            }
+            videoStart = videoStart.AddSeconds(videoDelay);
+            videoStop = videoStop.AddSeconds(videoDelay);
+
+            start = new DateTime(Math.Min(audioStart.Ticks, videoStart.Ticks));
+            stop = new DateTime(Math.Max(audioStop.Ticks, videoStop.Ticks));
 
             Assert.Single(context.Applications);
 

--- a/src/FM.LiveSwitch.Mux/Connection.cs
+++ b/src/FM.LiveSwitch.Mux/Connection.cs
@@ -136,22 +136,24 @@ namespace FM.LiveSwitch.Mux
                     ActiveRecording.VideoStopTimestamp = ActiveRecording.VideoStopTimestamp.Value.AddSeconds(videoDelay);
                 }
 
-                // update recording timestamps to match any changes to the audio timestamps
+                // ensure consistency on start/stop timestamps
+                var audioStartTimestampTicks = long.MaxValue;
+                var audioStopTimestampTicks = long.MinValue;
                 if (ActiveRecording.AudioFile != null)
                 {
-                    ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.AudioStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
-                    ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.AudioStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
+                    audioStartTimestampTicks = ActiveRecording.AudioStartTimestamp.Value.Ticks;
+                    audioStopTimestampTicks = ActiveRecording.AudioStopTimestamp.Value.Ticks;
                 }
-
-                // update recording timestamps to match any changes to the video timestamps
+                var videoStartTimestampTicks = long.MaxValue;
+                var videoStopTimestampTicks = long.MinValue;
                 if (ActiveRecording.VideoFile != null)
                 {
-                    ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.VideoStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
-                    ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.VideoStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
+                    videoStartTimestampTicks = ActiveRecording.VideoStartTimestamp.Value.Ticks;
+                    videoStopTimestampTicks = ActiveRecording.VideoStopTimestamp.Value.Ticks;
                 }
 
-                StartTimestamp = ActiveRecording.StartTimestamp;
-                StopTimestamp = ActiveRecording.StopTimestamp;
+                StartTimestamp = ActiveRecording.StartTimestamp = new DateTime(Math.Min(audioStartTimestampTicks, videoStartTimestampTicks));
+                StopTimestamp = ActiveRecording.StopTimestamp = new DateTime(Math.Max(audioStopTimestampTicks, videoStopTimestampTicks));
 
                 _Recordings.Add(ActiveRecording);
                 ActiveRecording = null;

--- a/src/FM.LiveSwitch.Mux/Connection.cs
+++ b/src/FM.LiveSwitch.Mux/Connection.cs
@@ -132,8 +132,8 @@ namespace FM.LiveSwitch.Mux
                 var videoDelay = logEntry.Data?.VideoDelay ?? 0D;
                 if (videoDelay != 0 && ActiveRecording.AudioFile != null && ActiveRecording.VideoFile != null)
                 {
-                    ActiveRecording.AudioStartTimestamp = ActiveRecording.AudioStartTimestamp.Value.AddSeconds(videoDelay);
-                    ActiveRecording.AudioStopTimestamp = ActiveRecording.AudioStopTimestamp.Value.AddSeconds(videoDelay);
+                    ActiveRecording.VideoStartTimestamp = ActiveRecording.VideoStartTimestamp.Value.AddSeconds(videoDelay);
+                    ActiveRecording.VideoStopTimestamp = ActiveRecording.VideoStopTimestamp.Value.AddSeconds(videoDelay);
                 }
 
                 // update recording timestamps to match any changes to the audio timestamps

--- a/src/FM.LiveSwitch.Mux/Connection.cs
+++ b/src/FM.LiveSwitch.Mux/Connection.cs
@@ -132,22 +132,22 @@ namespace FM.LiveSwitch.Mux
                 var videoDelay = logEntry.Data?.VideoDelay ?? 0D;
                 if (videoDelay != 0 && ActiveRecording.AudioFile != null && ActiveRecording.VideoFile != null)
                 {
-                    if (videoDelay < 0)
-                    {
-                        ActiveRecording.AudioStartTimestamp = ActiveRecording.AudioStartTimestamp.Value.AddSeconds(videoDelay);
-                        ActiveRecording.AudioStopTimestamp = ActiveRecording.AudioStopTimestamp.Value.AddSeconds(videoDelay);
+                    ActiveRecording.AudioStartTimestamp = ActiveRecording.AudioStartTimestamp.Value.AddSeconds(videoDelay);
+                    ActiveRecording.AudioStopTimestamp = ActiveRecording.AudioStopTimestamp.Value.AddSeconds(videoDelay);
+                }
 
-                        ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.AudioStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
-                        ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.AudioStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
-                    }
-                    else
-                    {
-                        ActiveRecording.VideoStartTimestamp = ActiveRecording.VideoStartTimestamp.Value.AddSeconds(-videoDelay);
-                        ActiveRecording.VideoStopTimestamp = ActiveRecording.VideoStopTimestamp.Value.AddSeconds(-videoDelay);
+                // update recording timestamps to match any changes to the audio timestamps
+                if (ActiveRecording.AudioFile != null)
+                {
+                    ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.AudioStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
+                    ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.AudioStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
+                }
 
-                        ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.VideoStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
-                        ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.VideoStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
-                    }
+                // update recording timestamps to match any changes to the video timestamps
+                if (ActiveRecording.VideoFile != null)
+                {
+                    ActiveRecording.StartTimestamp = new DateTime(Math.Min(ActiveRecording.VideoStartTimestamp.Value.Ticks, ActiveRecording.StartTimestamp.Ticks));
+                    ActiveRecording.StopTimestamp = new DateTime(Math.Max(ActiveRecording.VideoStopTimestamp.Value.Ticks, ActiveRecording.StopTimestamp.Ticks));
                 }
 
                 StartTimestamp = ActiveRecording.StartTimestamp;


### PR DESCRIPTION
- Fixes a logical error in applying the `videoDelay` from the `stopRecording` event. Also handles the case now where the timestamp of the first audio and/or video frame has an earlier timestamp than the timestamp of the `startRecording` event.