### PR TITLE
Check for index bounds before accessing Updates array

### DIFF
--- a/src/FM.LiveSwitch.Mux/Recording.cs
+++ b/src/FM.LiveSwitch.Mux/Recording.cs
@@ -254,7 +254,7 @@ namespace FM.LiveSwitch.Mux
                             }
 
                             // next update
-                            while (timestamp >= update.StopTimestamp)
+                            while (timestamp >= update.StopTimestamp && Updates.Length > updateIndex+1)
                             {
                                 updateIndex++;
                                 update = Updates[updateIndex];


### PR DESCRIPTION
Before accessing the array, added a check for index against the size of `Updates` array to avoid `IndexOutOfRangeException` exception.