### PR TITLE
Allow input files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ lsmux [options]
   -i, --input-path      The input path, i.e. the recording path used by the media server.
                         Defaults to the current directory.
 
+  -j, --input-files     The input json file names from the media server separeated by a comma 
+                        (',').
+                        
   -o, --output-path     The output path for muxed sessions. Defaults to the input path.
 
   -t, --temp-path       The path for temporary intermediate files. Defaults to the input path.
@@ -114,6 +117,8 @@ lsmux [options]
   --dry-run             Do a dry-run with no muxing.
 
   --session-id          The session ID to mux, obtained from a dry-run.
+
+  --filter-files        Process only the files listed in the input-files argument.
 ```
 
 The `input-path` to your recordings defaults to the current directory, but can be set to target another directory on disk.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ lsmux [options]
   -i, --input-path      The input path, i.e. the recording path used by the media server.
                         Defaults to the current directory.
 
-  -j, --input-files     The input json file names from the media server separeated by a comma 
-                        (',').
-                        
   -o, --output-path     The output path for muxed sessions. Defaults to the input path.
 
   -t, --temp-path       The path for temporary intermediate files. Defaults to the input path.
@@ -118,7 +115,10 @@ lsmux [options]
 
   --session-id          The session ID to mux, obtained from a dry-run.
 
-  --filter-files        Process only the files listed in the input-files argument.
+  --input-filter        A regular expression used to filter the input file list.
+  
+  --input-file-names    A comma separated list of input files to target instead of scanning the
+                        directory.
 ```
 
 The `input-path` to your recordings defaults to the current directory, but can be set to target another directory on disk.

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -13,7 +13,7 @@ namespace FM.LiveSwitch.Mux
         [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
 
-        [Option('k', "input-files", Required = true, Separator = ',', HelpText = "The input json files from the media server separeated by a comma (',').")]
+        [Option('j', "input-files", Required = true, Separator = ',', HelpText = "The input json file names from the media server separeated by a comma (',').")]
         public IEnumerable<string> InputFiles { get; set; }
 
         [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using System;
+using System.Collections.Generic;
 
 namespace FM.LiveSwitch.Mux
 {
@@ -11,6 +12,9 @@ namespace FM.LiveSwitch.Mux
 
         [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
+
+        [Option('k', "input-files", Required = true, Separator = ',', HelpText = "The input json files from the media server separeated by a comma (',').")]
+        public IEnumerable<string> InputFiles { get; set; }
 
         [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]
         public string OutputPath { get; set; }

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -13,7 +13,7 @@ namespace FM.LiveSwitch.Mux
         [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
 
-        [Option('j', "input-files", Required = true, Separator = ',', HelpText = "The input json file names from the media server separeated by a comma (',').")]
+        [Option('j', "input-files", Separator = ',', HelpText = "The input json file names from the media server separeated by a comma (',').")]
         public IEnumerable<string> InputFiles { get; set; }
 
         [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]
@@ -105,5 +105,8 @@ namespace FM.LiveSwitch.Mux
 
         [Option("session-id", HelpText = "The session ID to mux, obtained from a dry-run.")]
         public Guid? SessionId { get; set; }
+
+        [Option("filter-files", HelpText = "Process only the files listed in the input-files argument.")]
+        public bool FilterFiles { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -14,9 +14,6 @@ namespace FM.LiveSwitch.Mux
         [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
 
-        [Option('j', "input-files", Separator = ArgSeparator, HelpText = "The input json file names from the media server separeated by a comma (',').")]
-        public IEnumerable<string> InputFiles { get; set; }
-
         [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]
         public string OutputPath { get; set; }
 
@@ -107,7 +104,10 @@ namespace FM.LiveSwitch.Mux
         [Option("session-id", HelpText = "The session ID to mux, obtained from a dry-run.")]
         public Guid? SessionId { get; set; }
 
-        [Option("filter-files", HelpText = "Process only the files listed in the input-files argument.")]
-        public bool FilterFiles { get; set; }
+        [Option("input-filter", HelpText = "A regular expression used to filter the input file list.")]
+        public string InputFilter { get; set; }
+
+        [Option("input-file-names", Separator = ArgSeparator, HelpText = "A comma separated list of input files to target instead of scanning the directory.")]
+        public IEnumerable<string> InputFileNames { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -9,11 +9,12 @@ namespace FM.LiveSwitch.Mux
         public const int MinMargin = 0;
         public const int MinWidth = 160;
         public const int MinHeight = 120;
+        public const char ArgSeparator = ',';
 
         [Option('i', "input-path", HelpText = "The input path, i.e. the recording path used by the media server. Defaults to the current directory.")]
         public string InputPath { get; set; }
 
-        [Option('j', "input-files", Separator = ',', HelpText = "The input json file names from the media server separeated by a comma (',').")]
+        [Option('j', "input-files", Separator = ArgSeparator, HelpText = "The input json file names from the media server separeated by a comma (',').")]
         public IEnumerable<string> InputFiles { get; set; }
 
         [Option('o', "output-path", HelpText = "The output path for muxed sessions. Defaults to the input path.")]

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -27,7 +27,7 @@ namespace FM.LiveSwitch.Mux
 
             if (Options.InputFiles.Count() == 0)
             {
-                Console.Error.WriteLine($"Missing imput files option.");
+                Console.Error.WriteLine($"No input file names provided. Use --help option for more details about available options.");
                 return false;
             }
             else

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -266,6 +266,10 @@ namespace FM.LiveSwitch.Mux
                             if (File.Exists(filePath))
                             {
                                 logEntries.AddRange(await LogUtility.GetEntries(filePath));
+                            } 
+                            else
+                            {
+                                Console.Error.WriteLine($"Could not locate file {fileName} in input directory {Options.InputPath}.");
                             }
                         }
                         return logEntries.ToArray();

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -1,5 +1,4 @@
-﻿using CommandLine.Text;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -30,6 +29,11 @@ namespace FM.LiveSwitch.Mux
             {
                 Console.Error.WriteLine($"Missing imput files option.");
                 return false;
+            }
+            else
+            {
+                // CommandLine.Parser returns empty strings when there is a space after the separator.
+                Options.InputFiles = Options.InputFiles.Where(fileName => fileName.Length > 0);
             }
 
             if (Options.OutputPath == null)

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -33,7 +33,10 @@ namespace FM.LiveSwitch.Mux
             else if (Options.InputFiles.Count() > 0)
             {
                 // CommandLine.Parser returns empty strings when there is a space after the separator.
-                Options.InputFiles = Options.InputFiles.Where(fileName => fileName.Length > 0);
+                // Also, CommandLine.Parser leaves the separator on the string sometimes.
+                Options.InputFiles = string.Join(MuxOptions.ArgSeparator, Options.InputFiles)
+                                            .Split(MuxOptions.ArgSeparator)
+                                            .Where(fileName => fileName.Length > 0);
             }
 
             if (Options.OutputPath == null)

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Mux
@@ -23,20 +24,6 @@ namespace FM.LiveSwitch.Mux
             {
                 Options.InputPath = Environment.CurrentDirectory;
                 Console.Error.WriteLine($"Input path defaulting to: {Options.InputPath}");
-            }
-
-            if (Options.InputFiles.Count() == 0 && Options.FilterFiles)
-            {
-                Console.Error.WriteLine($"No input file names provided. Use --help option for more details about available options.");
-                return false;
-            }
-            else if (Options.InputFiles.Count() > 0)
-            {
-                // CommandLine.Parser returns empty strings when there is a space after the separator.
-                // Also, CommandLine.Parser leaves the separator on the string sometimes.
-                Options.InputFiles = string.Join(MuxOptions.ArgSeparator, Options.InputFiles)
-                                            .Split(MuxOptions.ArgSeparator)
-                                            .Where(fileName => fileName.Length > 0);
             }
 
             if (Options.OutputPath == null)
@@ -82,6 +69,15 @@ namespace FM.LiveSwitch.Mux
             {
                 Console.Error.WriteLine($"Height updated from {Options.Height} to the minimum value of {MuxOptions.MinHeight}.");
                 Options.Height = MuxOptions.MinHeight;
+            }
+
+            if (Options.InputFileNames.Count() > 0)
+            {
+                // CommandLine.Parser returns empty strings when there is a space after the separator.
+                // Also, CommandLine.Parser leaves the separator in the string sometimes.
+                Options.InputFileNames = string.Join(MuxOptions.ArgSeparator, Options.InputFileNames)
+                                            .Split(MuxOptions.ArgSeparator)
+                                            .Where(fileName => fileName.Length > 0);
             }
 
             var logEntries = await GetLogEntries(Options);
@@ -253,9 +249,26 @@ namespace FM.LiveSwitch.Mux
                 case StrategyType.Flat:
                     {
                         var logEntries = new List<LogEntry>();
-                        foreach (var filePath in Directory.EnumerateFiles(options.InputPath, "*.*", SearchOption.TopDirectoryOnly))
+                        IEnumerable<string> filePaths;
+
+                        if (Options.InputFileNames.Count() == 0)
                         {
-                            if (ShouldProcessFile(filePath, options))
+                            filePaths = Directory.EnumerateFiles(Options.InputPath, "*", SearchOption.TopDirectoryOnly);
+                        }
+                        else
+                        {
+                            filePaths = Options.InputFileNames.Select(inputFileName => Path.Combine(Options.InputPath, inputFileName));
+                        }
+
+                        foreach (var filePath in filePaths)
+                        {
+                            // filter the input files if a filter is provided.
+                            if (Options.InputFilter != null && !Regex.Match(Path.GetFileName(filePath), Options.InputFilter).Success)
+                            {
+                                continue;
+                            }
+
+                            if (filePath.EndsWith(".json") || filePath.EndsWith(".json.rec"))
                             {
                                 try
                                 {
@@ -276,15 +289,6 @@ namespace FM.LiveSwitch.Mux
                 default:
                     throw new Exception("Unrecognized strategy.");
             }
-        }
-
-        private bool ShouldProcessFile(string filePath, MuxOptions options)
-        {
-            var isJsonFile = filePath.EndsWith(".json") || filePath.EndsWith(".json.rec");
-            var isFileFiltered = options.InputFiles.Contains(Path.GetFileName(filePath)) || options.InputFiles.Contains(Path.GetFileNameWithoutExtension(filePath));
-
-            return (!options.FilterFiles && isJsonFile) 
-                || (options.FilterFiles && isJsonFile && isFileFiltered);
         }
 
         private string Move(string file, MuxOptions options)

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -253,7 +253,7 @@ namespace FM.LiveSwitch.Mux
 
                         if (Options.InputFileNames.Count() == 0)
                         {
-                            filePaths = Directory.EnumerateFiles(Options.InputPath, "*", SearchOption.TopDirectoryOnly);
+                            filePaths = Directory.EnumerateFiles(Options.InputPath, "*.*", SearchOption.TopDirectoryOnly);
                         }
                         else
                         {


### PR DESCRIPTION
Added `--input-files` option to read only the files with filenames provided in the directory `input-path`. Multiple file names can be provided in a comma-separated string.

This is in the effort to make sure multiple muxers running in the same `input-path` don't affect each other if they have different json files to work on.