### PR TITLE
Added move-path option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,20 @@
 # Contributing
 
 When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository. 
+email, or any other method with the owners of this repository.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
 ## Pull Request Process
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
-   build.
-2. Update the README.md with details of changes to the interface, this includes new environment 
-   variables, exposed ports, useful file locations and container parameters.
-3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
-   do not have permission to do that, you may request the second reviewer to merge it for you.
+1.  Ensure any install or build dependencies are removed before the end of the layer when doing a
+    build.
+
+2.  Update the README.md with details of changes to the interface, this includes new environment
+    variables, exposed ports, useful file locations and container parameters.
+
+3.  You may merge the Pull Request in once you have the sign-off of two other developers, or if you
+    do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Code of Conduct
 
@@ -30,22 +32,26 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+
+*   Public or private harassment
+
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
 
 ### Our Responsibilities
 
@@ -71,7 +77,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at <mailto:support@frozenmountain.com>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -87,4 +93,5 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
+
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ lsmux [options]
 
   --no-video            Do not mux video.
 
-  --move-inputs         Move input files to the output path.
+  --move-inputs         Move input files to the move path.
+
+  --move-path           The destination path for moved files. Defaults to the output path.
 
   --delete-inputs       Delete input files from the input path.
 
@@ -116,7 +118,7 @@ lsmux [options]
   --session-id          The session ID to mux, obtained from a dry-run.
 
   --input-filter        A regular expression used to filter the input file list.
-  
+
   --input-file-names    A comma separated list of input files to target instead of scanning the
                         directory.
 ```

--- a/src/FM.LiveSwitch.Mux/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux/MuxOptions.cs
@@ -65,8 +65,11 @@ namespace FM.LiveSwitch.Mux
         [Option("no-video", HelpText = "Do not mux video.")]
         public bool NoVideo { get; set; }
 
-        [Option("move-inputs", HelpText = "Move input files to the output path.")]
+        [Option("move-inputs", HelpText = "Move input files to the move path.")]
         public bool MoveInputs { get; set; }
+
+        [Option("move-path", HelpText = "The destination path for moved files. Defaults to the output path.")]
+        public string MovePath { get; set; }
 
         [Option("delete-inputs", HelpText = "Delete input files from the input path.")]
         public bool DeleteInputs { get; set; }

--- a/src/FM.LiveSwitch.Mux/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux/Muxer.cs
@@ -38,6 +38,12 @@ namespace FM.LiveSwitch.Mux
                 Console.Error.WriteLine($"Temp path defaulting to: {Options.TempPath}");
             }
 
+            if (Options.MoveInputs && Options.MovePath == null)
+            {
+                Options.MovePath = Options.OutputPath;
+                Console.Error.WriteLine($"Move path defaulting to: {Options.MovePath}");
+            }
+
             if (Options.Layout == LayoutType.JS)
             {
                 if (Options.JavaScriptFile == null)
@@ -133,7 +139,7 @@ namespace FM.LiveSwitch.Mux
 
                             if (Options.MoveInputs)
                             {
-                                if (Options.InputPath != Options.OutputPath)
+                                if (Options.InputPath != Options.MovePath)
                                 {
                                     foreach (var recording in session.CompletedRecordings)
                                     {
@@ -293,12 +299,12 @@ namespace FM.LiveSwitch.Mux
 
         private string Move(string file, MuxOptions options)
         {
-            var newFile = file.Replace(options.InputPath, options.OutputPath, StringComparison.InvariantCultureIgnoreCase);
+            var newFile = file.Replace(options.InputPath, options.MovePath, StringComparison.InvariantCultureIgnoreCase);
 
-            var outputPath = Path.GetDirectoryName(newFile);
-            if (!Directory.Exists(outputPath))
+            var movePath = Path.GetDirectoryName(newFile);
+            if (!Directory.Exists(movePath))
             {
-                Directory.CreateDirectory(outputPath);
+                Directory.CreateDirectory(movePath);
             }
 
             try


### PR DESCRIPTION
Closes #21.

- Adds a `--move-path` option to allow moving input files to a path other than the `--output-path`.