### PR TITLE
Using ffprobe to determine actual media duration

### DIFF
--- a/src/FM.LiveSwitch.Mux.Standard/Application.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Application.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Mux
 {
@@ -17,13 +18,17 @@ namespace FM.LiveSwitch.Mux
 
         private readonly Dictionary<string, Channel> _Channels = new Dictionary<string, Channel>();
 
-        public Application(string id, string externalId)
+        private readonly ILoggerFactory _LoggerFactory;
+
+        public Application(string id, string externalId, ILoggerFactory loggerFactory)
         {
             Id = id;
             ExternalId = externalId;
+
+            _LoggerFactory = loggerFactory;
         }
 
-        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options, ILoggerFactory loggerFactory)
+        public async Task<bool> ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var channelId = logEntry.ChannelId;
             if (channelId == null)
@@ -33,10 +38,10 @@ namespace FM.LiveSwitch.Mux
 
             if (!_Channels.TryGetValue(channelId, out var channel))
             {
-                _Channels[channelId] = channel = new Channel(channelId, Id, ExternalId);
+                _Channels[channelId] = channel = new Channel(channelId, Id, ExternalId, _LoggerFactory);
             }
 
-            return channel.ProcessLogEntry(logEntry, options, loggerFactory);
+            return await channel.ProcessLogEntry(logEntry, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux.Standard/Context.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Context.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Mux
 {
@@ -14,7 +14,14 @@ namespace FM.LiveSwitch.Mux
 
         private readonly Dictionary<string, Application> _Applications = new Dictionary<string, Application>();
 
-        public bool ProcessLogEntry(LogEntry logEntry, MuxOptions options, ILoggerFactory loggerFactory)
+        private readonly ILoggerFactory _LoggerFactory;
+
+        public Context(ILoggerFactory loggerFactory)
+        {
+            _LoggerFactory = loggerFactory;
+        }
+
+        public async Task<bool> ProcessLogEntry(LogEntry logEntry, MuxOptions options)
         {
             var applicationId = logEntry.ApplicationId;
             if (applicationId == null)
@@ -24,10 +31,10 @@ namespace FM.LiveSwitch.Mux
 
             if (!_Applications.TryGetValue(applicationId, out var application))
             {
-                _Applications[applicationId] = application = new Application(applicationId, logEntry.ExternalId);
+                _Applications[applicationId] = application = new Application(applicationId, logEntry.ExternalId, _LoggerFactory);
             }
 
-            return application.ProcessLogEntry(logEntry, options, loggerFactory);
+            return await application.ProcessLogEntry(logEntry, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/FM.LiveSwitch.Mux.Standard/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Muxer.cs
@@ -145,7 +145,7 @@ namespace FM.LiveSwitch.Mux
                     _Logger.LogDebug("Found {Count} log entries.", logEntries.Count());
 
                     // process each log entry
-                    var context = new Context();
+                    var context = new Context(LoggerFactory);
                     foreach (var logEntry in logEntries)
                     {
                         _Logger.LogDebug("Processing log entry for application ID '{ApplicationId}', channel ID '{ChannelId}', client ID '{ClientId}', and connection ID '{ConnectionId}'.",
@@ -153,7 +153,7 @@ namespace FM.LiveSwitch.Mux
                             logEntry.ChannelId,
                             logEntry.ClientId,
                             logEntry.ConnectionId);
-                        context.ProcessLogEntry(logEntry, Options, LoggerFactory);
+                        await context.ProcessLogEntry(logEntry, Options).ConfigureAwait(false);
                     }
 
                     // process the results

--- a/src/FM.LiveSwitch.Mux.Standard/Session.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Session.cs
@@ -164,7 +164,7 @@ namespace FM.LiveSwitch.Mux
         }
 
         private readonly ILogger _Logger;
-        private readonly Utility _FfmpegUtility;
+        private readonly Utility _Utility;
 
         public Session(string channelId, string applicationId, string externalId, Client[] completedClients, ILoggerFactory loggerFactory)
         {
@@ -175,7 +175,7 @@ namespace FM.LiveSwitch.Mux
             LoggerFactory = loggerFactory;
 
             _Logger = loggerFactory.CreateLogger(nameof(Session));
-            _FfmpegUtility = new Utility(_Logger);
+            _Utility = new Utility(_Logger);
         }
 
         public async Task<bool> Mux(MuxOptions options)
@@ -242,7 +242,7 @@ namespace FM.LiveSwitch.Mux
             }
 
             // run it
-            await _FfmpegUtility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
+            await _Utility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
 
             return FileExists;
         }
@@ -374,7 +374,7 @@ namespace FM.LiveSwitch.Mux
                 }
 
                 // run it
-                await _FfmpegUtility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
+                await _Utility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
 
                 return AudioFileExists;
             }
@@ -687,7 +687,7 @@ namespace FM.LiveSwitch.Mux
                     }
 
                     // run it
-                    await _FfmpegUtility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
+                    await _Utility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -745,7 +745,7 @@ namespace FM.LiveSwitch.Mux
                 }
 
                 // run it
-                await _FfmpegUtility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
+                await _Utility.FFmpeg(string.Join(" ", arguments)).ConfigureAwait(false);
 
                 return VideoFileExists;
             }
@@ -853,7 +853,7 @@ namespace FM.LiveSwitch.Mux
 
         public async Task<string> GetAudioCodec(Recording recording)
         {
-            var lines = await _FfmpegUtility.FFprobe($"-v quiet -select_streams a:0 -show_entries stream=codec_name -print_format csv=print_section=0 {recording.AudioFile}").ConfigureAwait(false);
+            var lines = await _Utility.FFprobe($"-v quiet -select_streams a:0 -show_entries stream=codec_name -print_format csv=print_section=0 {recording.AudioFile}").ConfigureAwait(false);
             if (lines.Length == 0)
             {
                 return null;
@@ -863,7 +863,7 @@ namespace FM.LiveSwitch.Mux
 
         public async Task<string> GetVideoCodec(Recording recording)
         {
-            var lines = await _FfmpegUtility.FFprobe($"-v quiet -select_streams v:0 -show_entries stream=codec_name -print_format csv=print_section=0 {recording.VideoFile}").ConfigureAwait(false);
+            var lines = await _Utility.FFprobe($"-v quiet -select_streams v:0 -show_entries stream=codec_name -print_format csv=print_section=0 {recording.VideoFile}").ConfigureAwait(false);
             if (lines.Length == 0)
             {
                 return null;
@@ -873,7 +873,7 @@ namespace FM.LiveSwitch.Mux
 
         public async Task<VideoSegment[]> ParseVideoSegments(Recording recording)
         {
-            var lines = await _FfmpegUtility.FFprobe($"-v quiet -select_streams v:0 -show_frames -show_entries frame=pkt_pts_time,width,height -print_format csv=item_sep=|:nokey=1:print_section=0 {recording.VideoFile}").ConfigureAwait(false);
+            var lines = await _Utility.FFprobe($"-v quiet -select_streams v:0 -show_frames -show_entries frame=pkt_pts_time,width,height -print_format csv=item_sep=|:nokey=1:print_section=0 {recording.VideoFile}").ConfigureAwait(false);
 
             var currentSize = Size.Empty;
             var segments = new List<VideoSegment>();

--- a/src/FM.LiveSwitch.Mux.Test/ContextTests.cs
+++ b/src/FM.LiveSwitch.Mux.Test/ContextTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace FM.LiveSwitch.Mux.Test
@@ -13,7 +14,7 @@ namespace FM.LiveSwitch.Mux.Test
         [InlineData(0)]
         [InlineData(-1)]
         [InlineData(1)]
-        public void VideoDelayUpdatesSession(double videoDelay)
+        public async Task VideoDelayUpdatesSession(double videoDelay)
         {
             using var loggerFactory = LoggerFactory.Create(builder => { });
             var start = new DateTime(1970, 1, 1, 0, 0, 0);
@@ -29,8 +30,8 @@ namespace FM.LiveSwitch.Mux.Test
 
             var options = new MuxOptions();
 
-            var context = new Context();
-            context.ProcessLogEntry(new LogEntry
+            var context = new Context(loggerFactory);
+            await context.ProcessLogEntry(new LogEntry
             {
                 ExternalId = externalId,
                 ApplicationId = applicationId,
@@ -41,8 +42,8 @@ namespace FM.LiveSwitch.Mux.Test
                 Type = LogEntry.TypeStartRecording,
                 Timestamp = start,
                 UserId = userId,
-            }, options, loggerFactory);
-            context.ProcessLogEntry(new LogEntry
+            }, options).ConfigureAwait(false);
+            await context.ProcessLogEntry(new LogEntry
             {
                 ExternalId = externalId,
                 ApplicationId = applicationId,
@@ -63,7 +64,7 @@ namespace FM.LiveSwitch.Mux.Test
                 Type = LogEntry.TypeStopRecording,
                 Timestamp = stop,
                 UserId = userId,
-            }, options, loggerFactory);
+            }, options).ConfigureAwait(false);
 
             var audioStart = start;
             var videoStart = start;

--- a/src/FM.LiveSwitch.Mux.Test/RecordingTests.cs
+++ b/src/FM.LiveSwitch.Mux.Test/RecordingTests.cs
@@ -471,24 +471,12 @@ namespace FM.LiveSwitch.Mux.Test
                     Assert.Equal(jsonVideoFile, newVideoFile);
 
                     var firstVideoTimestamp = data["videoFirstFrameTimestamp"]?.Value<DateTime>();
-                    var lastVideoTimestamp = data["videoLastFrameTimestamp"]?.Value<DateTime>();
                     var firstAudioTimestamp = data["audioFirstFrameTimestamp"]?.Value<DateTime>();
-                    var lastAudioTimestamp = data["audioLastFrameTimestamp"]?.Value<DateTime>();
 
                     Assert.NotNull(firstVideoTimestamp);
-                    Assert.NotNull(lastVideoTimestamp);
                     Assert.NotNull(firstAudioTimestamp);
-                    Assert.NotNull(lastAudioTimestamp);
                     Assert.Equal(firstAudioTimestamp, timestamp1);
                     Assert.Equal(firstVideoTimestamp, timestamp1);
-                    Assert.True(firstVideoTimestamp <= lastVideoTimestamp);
-                    Assert.True(firstAudioTimestamp <= lastAudioTimestamp);
-
-                    var audioDuration = (lastAudioTimestamp - firstAudioTimestamp)?.Seconds;
-                    var videoDuration = (lastVideoTimestamp - firstVideoTimestamp)?.Seconds;
-
-                    Assert.Equal(16, audioDuration);
-                    Assert.Equal(9, videoDuration);
                 }
             }
             finally


### PR DESCRIPTION
- When possible, use `ffprobe` to determine the media file duration instead of relying on `audioLastFrameTimestamp` or `videoLastFrameTimestamp`. This provides a more consistent value to the muxing engine and external callers.