### PR TITLE
Screen Weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ lsmux [options]
 
   --crop                   Crop video in order to use all available layout space.
 
+  --camera-weight          (Default: 1) How much layout space to use for camera content relative
+                           to other content. Ignored for JS layout.
+
+  --screen-weight          (Default: 5) How much layout space to use for screen content relative
+                           to other content. Ignored for JS layout.
+
   --no-audio               Do not mux audio.
 
   --no-video               Do not mux video.

--- a/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
@@ -58,6 +58,12 @@ namespace FM.LiveSwitch.Mux
         [Option("crop", HelpText = "Crop video in order to use all available layout space.")]
         public bool Crop { get; set; }
 
+        [Option("camera-weight", Default = 1, HelpText = "How much layout space to use for camera content relative to other content. Ignored for JS layout.")]
+        public int CameraWeight { get; set; }
+
+        [Option("screen-weight", Default = 5, HelpText = "How much layout space to use for screen content relative to other content. Ignored for JS layout.")]
+        public int ScreenWeight { get; set; }
+
         [Option("no-audio", HelpText = "Do not mux audio.")]
         public bool NoAudio { get; set; }
 

--- a/src/FM.LiveSwitch.Mux.Standard/Muxer.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Muxer.cs
@@ -95,6 +95,20 @@ namespace FM.LiveSwitch.Mux
                         Options.Height = minHeight;
                     }
 
+                    var minCameraWeight = 1;
+                    if (Options.CameraWeight < minCameraWeight)
+                    {
+                        _Logger.LogInformation("Camera weight updated from {CameraWeight} to the minimum value of {MinCameraWeight}.", Options.CameraWeight, minCameraWeight);
+                        Options.CameraWeight = minCameraWeight;
+                    }
+
+                    var minScreenWeight = 1;
+                    if (Options.ScreenWeight < minScreenWeight)
+                    {
+                        _Logger.LogInformation("Screen weight updated from {ScreenWeight} to the minimum value of {MinScreenWeight}.", Options.ScreenWeight, minScreenWeight);
+                        Options.ScreenWeight = minScreenWeight;
+                    }
+
                     if (Options.InputFileNames.Count() > 0)
                     {
                         // CommandLine.Parser returns empty strings when there is a space after the separator.

--- a/src/FM.LiveSwitch.Mux.Standard/Session.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Session.cs
@@ -563,7 +563,7 @@ namespace FM.LiveSwitch.Mux
                     {
                         StartTimestamp = chunks.Last().StopTimestamp,
                         StopTimestamp = @event.Timestamp,
-                        Layout = Layout.Calculate(options.Layout, new LayoutInput[0], layoutOutput, options.JavaScriptFile),
+                        Layout = Layout.Calculate(options.Layout, options.CameraWeight, options.ScreenWeight, new LayoutInput[0], layoutOutput, options.JavaScriptFile),
                         Segments = new VideoSegment[0]
                     });
                 }
@@ -588,11 +588,11 @@ namespace FM.LiveSwitch.Mux
                     // calculate the layout
                     if (options.Dynamic)
                     {
-                        chunk.Layout = Layout.Calculate(options.Layout, chunk.Segments.Select(x => x.GetLayoutInput()).ToArray(), layoutOutput, options.JavaScriptFile);
+                        chunk.Layout = Layout.Calculate(options.Layout, options.CameraWeight, options.ScreenWeight, chunk.Segments.Select(x => x.GetLayoutInput()).ToArray(), layoutOutput, options.JavaScriptFile);
                     }
                     else
                     {
-                        chunk.Layout = Layout.Calculate(options.Layout, staticLayoutInputs.ToArray(), layoutOutput, options.JavaScriptFile);
+                        chunk.Layout = Layout.Calculate(options.Layout, options.CameraWeight, options.ScreenWeight, staticLayoutInputs.ToArray(), layoutOutput, options.JavaScriptFile);
                     }
 
                     chunks.Add(chunk);
@@ -608,7 +608,7 @@ namespace FM.LiveSwitch.Mux
                 {
                     StartTimestamp = StartTimestamp,
                     StopTimestamp = chunks[0].StartTimestamp,
-                    Layout = Layout.Calculate(options.Layout, new LayoutInput[0], layoutOutput, options.JavaScriptFile),
+                    Layout = Layout.Calculate(options.Layout, options.CameraWeight, options.ScreenWeight, new LayoutInput[0], layoutOutput, options.JavaScriptFile),
                     Segments = new VideoSegment[0]
                 });
             }

--- a/src/FM.LiveSwitch.Mux.Standard/VideoContent.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/VideoContent.cs
@@ -1,0 +1,8 @@
+﻿namespace FM.LiveSwitch.Mux
+{
+    public static class VideoContent
+    {
+        public static string Camera { get { return "camera"; } }
+        public static string Screen { get { return "screen"; } }
+    }
+}

--- a/src/FM.LiveSwitch.Mux.Test/LayoutTests.cs
+++ b/src/FM.LiveSwitch.Mux.Test/LayoutTests.cs
@@ -11,7 +11,7 @@ namespace FM.LiveSwitch.Mux.Test
         {
             var connectionId = Guid.NewGuid().ToString();
 
-            var layout = Layout.Calculate(LayoutType.JS, new[]
+            var layout = Layout.Calculate(LayoutType.JS, 1, 1, new[]
             {
                 new LayoutInput
                 {


### PR DESCRIPTION
- Added `screen-weight` and `camera-weight` arguments that factor in the new `screen` and `camera` content hints coming in LiveSwitch 1.13. By default, screen content will be featured more prominently (given more weight) in the output video. These parameters are ignored if the `layout` is `js`.