### PR TITLE
Timestamp bug fix

### DIFF
--- a/src/FM.LiveSwitch.Mux.Standard/Connection.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Connection.cs
@@ -28,9 +28,31 @@ namespace FM.LiveSwitch.Mux
         [JsonIgnore]
         public string ExternalId { get; private set; }
 
-        public DateTime? StartTimestamp { get; private set; }
+        public DateTime? StartTimestamp
+        {
+            get
+            {
+                var startTimestamps = CompletedRecordings.Select(x => x.StartTimestamp);
+                if (startTimestamps.Count() == 0)
+                {
+                    return null;
+                }
+                return startTimestamps.Min();
+            }
+        }
 
-        public DateTime? StopTimestamp { get; private set; }
+        public DateTime? StopTimestamp
+        {
+            get
+            {
+                var stopTimestamps = CompletedRecordings.Select(x => x.StopTimestamp);
+                if (stopTimestamps.Count() == 0)
+                {
+                    return null;
+                }
+                return stopTimestamps.Max();
+            }
+        }
 
         [JsonIgnore]
         public Recording ActiveRecording { get; private set; }
@@ -76,11 +98,6 @@ namespace FM.LiveSwitch.Mux
                     StartTimestamp = logEntry.Timestamp,
                     LogFile = logEntry.FilePath
                 };
-
-                if (StartTimestamp == null)
-                {
-                    StartTimestamp = logEntry.Timestamp;
-                }
 
                 ActiveRecording.Update(logEntry);
             }
@@ -154,8 +171,8 @@ namespace FM.LiveSwitch.Mux
                     videoStopTimestampTicks = ActiveRecording.VideoStopTimestamp.Value.Ticks;
                 }
 
-                StartTimestamp = ActiveRecording.StartTimestamp = new DateTime(Math.Min(audioStartTimestampTicks, videoStartTimestampTicks));
-                StopTimestamp = ActiveRecording.StopTimestamp = new DateTime(Math.Max(audioStopTimestampTicks, videoStopTimestampTicks));
+                ActiveRecording.StartTimestamp = new DateTime(Math.Min(audioStartTimestampTicks, videoStartTimestampTicks));
+                ActiveRecording.StopTimestamp = new DateTime(Math.Max(audioStopTimestampTicks, videoStopTimestampTicks));
 
                 _Recordings.Add(ActiveRecording);
                 ActiveRecording = null;


### PR DESCRIPTION
- Fixes a bug that could cause a negative `adelay` filter to be generated.

The `Connection` `StartTimestamp` should reflect the earliest `StartTimestamp` from the `CompletedRecordings` collection. Likewise, the `Connection` `StopTimestamp` should reflect the latest `StopTimestamp` from that same collection. This matches the approach taken in the `Client` where the `StartTimestamp` and `StopTimestamp` are the minimum and maximum `StartTimestamp` and `StopTimestamp` respectively from the `CompletedConnections` collection.

The old approach dynamically updated the `Connection` `StartTimestamp` to that of the `ActiveRecording`, which, if there are multiple recordings for a given connection, results in a `StartTimestamp` that reflects the `StartTimestamp` of the last recording instead of the first. This, in turn, can result in an incorrect `StartTimestamp` at the `Session` level, which looks to the `CompletedClients` to determine the start time. The `CompletedClients` looks to the `CompletedConnections` and so an invalid timestamp is returned.