### PR TITLE
UseShellExecute

### DIFF
--- a/src/FM.LiveSwitch.Mux.Standard/Utility.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Utility.cs
@@ -94,7 +94,8 @@ namespace FM.LiveSwitch.Mux
             {
                 WindowStyle = ProcessWindowStyle.Hidden,
                 FileName = command,
-                Arguments = arguments
+                Arguments = arguments,
+                UseShellExecute = false
             };
 
             if (standardStream == StandardStream.Error)


### PR DESCRIPTION
- An explicit value is set now for `UseShellExecute` (`false`) so that .NET Framework callers do not run into this exception:

```
System.InvalidOperationException: The Process object must have the UseShellExecute property set to false in order to redirect IO streams.
```

Per https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.useshellexecute?view=net-5.0:
> The default is true on .NET Framework apps and false on .NET Core apps.