### PR TITLE
add a flag to skip attempts to verify the length of streams

### DIFF
--- a/src/FM.LiveSwitch.Mux.Standard/Connection.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Connection.cs
@@ -148,7 +148,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.AudioFile = Path.Combine(options.InputPath, ActiveRecording.AudioFile);
                     }
 
-                    if (ActiveRecording.AudioStartTimestamp.HasValue)
+                    if (ActiveRecording.AudioStartTimestamp.HasValue && !options.NoVerifyLength)
                     {
                         var audioDuration = await GetDuration(true, ActiveRecording.AudioFile).ConfigureAwait(false);
                         if (audioDuration.HasValue)
@@ -186,7 +186,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else
+                    else if (!options.NoVerifyLength)
                     {
                         _Logger.LogError("Audio recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }
@@ -202,7 +202,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.VideoFile = Path.Combine(options.InputPath, ActiveRecording.VideoFile);
                     }
 
-                    if (ActiveRecording.VideoStartTimestamp.HasValue)
+                    if (ActiveRecording.VideoStartTimestamp.HasValue && !options.NoVerifyLength)
                     {
                         var videoDuration = await GetDuration(false, ActiveRecording.VideoFile).ConfigureAwait(false);
                         if (videoDuration.HasValue)
@@ -240,7 +240,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else
+                    else if(!options.NoVerifyLength)
                     {
                         _Logger.LogError("Video recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }

--- a/src/FM.LiveSwitch.Mux.Standard/Connection.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Connection.cs
@@ -148,7 +148,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.AudioFile = Path.Combine(options.InputPath, ActiveRecording.AudioFile);
                     }
 
-                    if (ActiveRecording.AudioStartTimestamp.HasValue && !options.SkipVerification)
+                    if (ActiveRecording.AudioStartTimestamp.HasValue && !options.SkipLengthVerification)
                     {
                         var audioDuration = await GetDuration(true, ActiveRecording.AudioFile).ConfigureAwait(false);
                         if (audioDuration.HasValue)
@@ -186,7 +186,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else if (!options.SkipVerification)
+                    else if (!options.SkipLengthVerification)
                     {
                         _Logger.LogError("Audio recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }
@@ -202,7 +202,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.VideoFile = Path.Combine(options.InputPath, ActiveRecording.VideoFile);
                     }
 
-                    if (ActiveRecording.VideoStartTimestamp.HasValue && !options.SkipVerification)
+                    if (ActiveRecording.VideoStartTimestamp.HasValue && !options.SkipLengthVerification)
                     {
                         var videoDuration = await GetDuration(false, ActiveRecording.VideoFile).ConfigureAwait(false);
                         if (videoDuration.HasValue)
@@ -240,7 +240,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else if(!options.SkipVerification)
+                    else if(!options.SkipLengthVerification)
                     {
                         _Logger.LogError("Video recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }

--- a/src/FM.LiveSwitch.Mux.Standard/Connection.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Connection.cs
@@ -148,7 +148,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.AudioFile = Path.Combine(options.InputPath, ActiveRecording.AudioFile);
                     }
 
-                    if (ActiveRecording.AudioStartTimestamp.HasValue && !options.NoVerifyLength)
+                    if (ActiveRecording.AudioStartTimestamp.HasValue && !options.SkipVerification)
                     {
                         var audioDuration = await GetDuration(true, ActiveRecording.AudioFile).ConfigureAwait(false);
                         if (audioDuration.HasValue)
@@ -186,7 +186,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else if (!options.NoVerifyLength)
+                    else if (!options.SkipVerification)
                     {
                         _Logger.LogError("Audio recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }
@@ -202,7 +202,7 @@ namespace FM.LiveSwitch.Mux
                         ActiveRecording.VideoFile = Path.Combine(options.InputPath, ActiveRecording.VideoFile);
                     }
 
-                    if (ActiveRecording.VideoStartTimestamp.HasValue && !options.NoVerifyLength)
+                    if (ActiveRecording.VideoStartTimestamp.HasValue && !options.SkipVerification)
                     {
                         var videoDuration = await GetDuration(false, ActiveRecording.VideoFile).ConfigureAwait(false);
                         if (videoDuration.HasValue)
@@ -240,7 +240,7 @@ namespace FM.LiveSwitch.Mux
                             }
                         }
                     }
-                    else if(!options.NoVerifyLength)
+                    else if(!options.SkipVerification)
                     {
                         _Logger.LogError("Video recording with connection ID '{ConnectionId}' has no start timestamp. Is the JSON log file corrupt?", Id);
                     }

--- a/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
@@ -130,7 +130,7 @@ namespace FM.LiveSwitch.Mux
         [Option("input-file-paths", Separator = ',', HelpText = "A comma separated list of input file paths to target instead of scanning the directory. Overrides --input-path and --input-file-names.")]
         public IEnumerable<string> InputFilePaths { get; set; }
 
-        [Option("no-verify-length", HelpText = "Skip verification and repair of stream length metadata")]
-        public bool NoVerifyLength { get; set; }
+        [Option("skip-length-verification", HelpText = "Skip verification and repair of stream length metadata")]
+        public bool SkipVerification { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
@@ -131,6 +131,6 @@ namespace FM.LiveSwitch.Mux
         public IEnumerable<string> InputFilePaths { get; set; }
 
         [Option("skip-length-verification", HelpText = "Skip verification and repair of stream length metadata")]
-        public bool SkipVerification { get; set; }
+        public bool SkipLengthVerification { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/MuxOptions.cs
@@ -129,5 +129,8 @@ namespace FM.LiveSwitch.Mux
 
         [Option("input-file-paths", Separator = ',', HelpText = "A comma separated list of input file paths to target instead of scanning the directory. Overrides --input-path and --input-file-names.")]
         public IEnumerable<string> InputFilePaths { get; set; }
+
+        [Option("no-verify-length", HelpText = "Skip verification and repair of stream length metadata")]
+        public bool NoVerifyLength { get; set; }
     }
 }


### PR DESCRIPTION
Needed by the legacy recording service to avoid potentially expensive calls to ffprobe