### PR TITLE
[LS1-384] ensure default timestamps are valid

### DIFF
--- a/src/FM.LiveSwitch.Mux.Standard/Connection.cs
+++ b/src/FM.LiveSwitch.Mux.Standard/Connection.cs
@@ -256,16 +256,16 @@ namespace FM.LiveSwitch.Mux
                 }
 
                 // ensure consistency on start/stop timestamps
-                var audioStartTimestampTicks = long.MaxValue;
-                var audioStopTimestampTicks = long.MinValue;
+                var audioStartTimestampTicks = DateTime.MaxValue.Ticks;
+                var audioStopTimestampTicks = DateTime.MinValue.Ticks;
                 if (ActiveRecording.AudioFile != null && ActiveRecording.AudioStartTimestamp.HasValue && ActiveRecording.AudioStopTimestamp.HasValue)
                 {
                     audioStartTimestampTicks = ActiveRecording.AudioStartTimestamp.Value.Ticks;
                     audioStopTimestampTicks = ActiveRecording.AudioStopTimestamp.Value.Ticks;
                 }
 
-                var videoStartTimestampTicks = long.MaxValue;
-                var videoStopTimestampTicks = long.MinValue;
+                var videoStartTimestampTicks = DateTime.MaxValue.Ticks;
+                var videoStopTimestampTicks = DateTime.MinValue.Ticks;
                 if (ActiveRecording.VideoFile != null && ActiveRecording.VideoStartTimestamp.HasValue && ActiveRecording.VideoStopTimestamp.HasValue)
                 {
                     videoStartTimestampTicks = ActiveRecording.VideoStartTimestamp.Value.Ticks;


### PR DESCRIPTION
This resolves an exception we were seeing when the timestamps in the json were invalid. This meant we were using the default values (long.Min/MaxValue) which are not valid for initializing datetime.